### PR TITLE
RSTP Hardware Support

### DIFF
--- a/rtl/hash/hash_multicast.v
+++ b/rtl/hash/hash_multicast.v
@@ -1,0 +1,270 @@
+`timescale 1ns / 1ps
+//////////////////////////////////////////////////////////////////////////////////
+// Company: 
+// Engineer: 
+// 
+// Create Date: 2022/06/13 11:20:18
+// Design Name: 
+// Module Name: hash_multicast
+// Project Name: 
+// Target Devices: 
+// Tool Versions: 
+// Description: 
+// Provide a configuable designated route for certain lldp-layer multicast packets incl. RSTP
+// Dependencies: 
+// 
+// Revision:
+// Revision 0.01 - File Created
+//
+// Additional Comments:
+// Direct attach to sys mgnt bus
+// ftm = flow table multicast
+//////////////////////////////////////////////////////////////////////////////////
+
+module hash_multicast #(
+    parameter   MGNT_REG_WIDTH      =   32,
+    localparam  MGNT_REG_WIDTH_L2   =   $clog2(MGNT_REG_WIDTH/8)
+) (
+    input               clk_if,
+    input               rst_if,
+    input               clk_sys,
+    input               rst_sys,
+
+    // frame_process side interface
+    input               ftm_req_valid,
+    input       [15:0]  ftm_req_mac,
+    // input       [15:0]  ftm_req_portmap,
+    output reg          ftm_resp_ack,
+    output reg          ftm_resp_nak,
+    output reg  [15:0]  ftm_resp_result,
+
+    // sys mgnt side interface
+    input               sys_req_valid,
+    input               sys_req_wr,
+    input       [ 7:0]  sys_req_addr,
+    output reg          sys_req_ack,
+    // sys mgnt side interface, tx channel
+    input       [ 7:0]  sys_req_data,
+    input               sys_req_data_valid,
+    // sys mgnt side interface, rx channel
+    output      [ 7:0]  sys_resp_data,
+    output reg          sys_resp_data_valid
+
+);
+
+    localparam  MGNT_FTM_ADDR_BRIDGE    =   8'h00;
+    localparam  MGNT_FTM_ADDR_MACCTL    =   8'h01;
+    localparam  MGNT_FTM_ADDR_ACCCTL    =   8'h02;
+    localparam  MGNT_FTM_ADDR_DEFRT0    =   8'h03;
+    localparam  MGNT_FTM_ADDR_DEFRT1    =   8'h04;
+
+    localparam  MAC_ADDR_MC_BRDGEGP =   16'h0000;
+    localparam  MAC_ADDR_MC_MACCTRL =   16'h0001;
+    localparam  MAC_ADDR_MC_ACCCTRL =   16'h0003;
+
+    reg     [15:0]  mgnt_reg_ftm_sys    [4:0];
+    reg     [15:0]  mgnt_reg_ftm_if     [4:0];
+
+    (*MARK_DEBUG = "true"*) reg     [ 2:0]  ftm_state, ftm_state_next;
+
+    // reg     [15:0]  ftm_port_bridge_group;
+    // reg     [15:0]  ftm_port_mac_ctrl;
+    // reg     [15:0]  ftm_port_access_ctrl;
+    // reg     [15:0]  ftm_port_def_0;
+    // reg     [15:0]  ftm_port_def_1;
+
+    reg     [ 5:0]  mgnt_state, mgnt_state_next;
+    reg             mgnt_rx_wr;
+    reg     [ 7:0]  mgnt_rx_addr;
+    reg     [MGNT_REG_WIDTH_L2-1:0]     mgnt_rx_cnt, mgnt_tx_cnt;
+    reg     [   MGNT_REG_WIDTH-1:0]     mgnt_rx_buf, mgnt_tx_buf;
+
+    always @(*) begin
+        case(ftm_state)
+            01 : ftm_state_next =   (ftm_req_valid)     ? 02 : 01;
+            02 : ftm_state_next =                              04;
+            04 : ftm_state_next =   (!ftm_req_valid)    ? 01 : 04;
+            default: ftm_state_next = ftm_state;
+        endcase
+    end
+
+    always @(posedge clk_sys) begin
+        if (!rst_sys) begin
+            ftm_state   <=  1;
+        end
+        else begin
+            ftm_state   <=  ftm_state_next;
+        end
+    end
+
+    always @(posedge clk_sys) begin
+        if (!rst_sys) begin
+            ftm_resp_ack    <=  'b0;
+            ftm_resp_nak    <=  'b0;
+            ftm_resp_result <=  'b0;
+        end
+        else begin
+            if (ftm_state[0]) begin
+                ftm_resp_ack    <=  'b0;
+                ftm_resp_nak    <=  'b0;
+            end
+            if (ftm_state[1]) begin
+                casex(ftm_req_mac)
+                    MAC_ADDR_MC_BRDGEGP: begin
+                        ftm_resp_ack    <=  'b1;
+                        ftm_resp_result <=  mgnt_reg_ftm_sys[MGNT_FTM_ADDR_BRIDGE];
+                    end
+                    MAC_ADDR_MC_MACCTRL: begin
+                        ftm_resp_ack    <=  'b1;
+                        ftm_resp_result <=  mgnt_reg_ftm_sys[MGNT_FTM_ADDR_MACCTL];
+                    end
+                    MAC_ADDR_MC_ACCCTRL: begin
+                        ftm_resp_ack    <=  'b1;
+                        ftm_resp_result <=  mgnt_reg_ftm_sys[MGNT_FTM_ADDR_ACCCTL];
+                    end
+                    16'h000X: begin
+                        ftm_resp_ack    <=  'b1;
+                        ftm_resp_result <=  mgnt_reg_ftm_sys[MGNT_FTM_ADDR_DEFRT0];
+                    end
+                    16'h001X: begin
+                        ftm_resp_ack    <=  'b1;
+                        ftm_resp_result <=  mgnt_reg_ftm_sys[MGNT_FTM_ADDR_DEFRT1];
+                    end
+                    default: begin
+                        ftm_resp_nak    <=  'b1;
+                        // ftm_resp_result <=  ~ftm_req_portmap;
+                    end
+                endcase
+            end
+        end
+    end
+
+    always @(posedge clk_sys) begin
+        if (!rst_sys) begin
+            mgnt_reg_ftm_sys[MGNT_FTM_ADDR_BRIDGE]  <=  16'h8;
+            mgnt_reg_ftm_sys[MGNT_FTM_ADDR_MACCTL]  <=  16'h0;
+            mgnt_reg_ftm_sys[MGNT_FTM_ADDR_ACCCTL]  <=  16'h8;
+            mgnt_reg_ftm_sys[MGNT_FTM_ADDR_DEFRT0]  <=  16'h8;
+            mgnt_reg_ftm_sys[MGNT_FTM_ADDR_DEFRT1]  <=  16'hF;
+        end
+        else begin
+            if (ftm_state_next[1] && (mgnt_state[0] || mgnt_state[1] || mgnt_state[2])) begin
+                mgnt_reg_ftm_sys[MGNT_FTM_ADDR_BRIDGE]  <=  mgnt_reg_ftm_if[MGNT_FTM_ADDR_BRIDGE];
+                mgnt_reg_ftm_sys[MGNT_FTM_ADDR_MACCTL]  <=  mgnt_reg_ftm_if[MGNT_FTM_ADDR_MACCTL];
+                mgnt_reg_ftm_sys[MGNT_FTM_ADDR_ACCCTL]  <=  mgnt_reg_ftm_if[MGNT_FTM_ADDR_ACCCTL];
+                mgnt_reg_ftm_sys[MGNT_FTM_ADDR_DEFRT0]  <=  mgnt_reg_ftm_if[MGNT_FTM_ADDR_DEFRT0];
+                mgnt_reg_ftm_sys[MGNT_FTM_ADDR_DEFRT1]  <=  mgnt_reg_ftm_if[MGNT_FTM_ADDR_DEFRT1];
+            end
+        end
+    end
+
+    always @(*) begin
+        case (mgnt_state)
+            // start transaction
+            01: mgnt_state_next =   sys_req_valid && sys_req_wr                 ? 08 :
+                                    sys_req_valid && !sys_req_wr                ? 02 : 01;
+            // read from reg stack
+            02: mgnt_state_next =   04;
+            // tx loop
+            04: mgnt_state_next =   (mgnt_tx_cnt == {MGNT_REG_WIDTH_L2{1'b1}})  ? 32 : 04;
+            // rx loop
+            08: mgnt_state_next =   (mgnt_rx_cnt == {MGNT_REG_WIDTH_L2{1'b1}})  ? 16 : 08;
+            // wait for endpt resp
+            16: mgnt_state_next =                                                 32;
+            // wait for handshake
+            32: mgnt_state_next =   (!sys_req_valid)                            ? 01 : 32;
+            // unexpected state trap
+            default: mgnt_state_next = mgnt_state;
+        endcase
+    end
+
+    always @(posedge clk_if) begin
+        if (!rst_if) begin
+            mgnt_state  <=  1;
+        end
+        else begin
+            mgnt_state  <=  mgnt_state_next;
+        end
+    end
+
+    always @(posedge clk_if) begin
+        if (!rst_if) begin
+            mgnt_rx_cnt <=  'b0;
+            mgnt_tx_cnt <=  'b0;
+        end
+        else begin
+            if (mgnt_state[0] && sys_req_valid) begin
+                mgnt_rx_wr      <=  sys_req_wr;
+                mgnt_rx_addr    <=  sys_req_addr;
+            end
+            if (mgnt_state[0]) begin
+                mgnt_tx_cnt <=  'b0;
+            end
+            else if (mgnt_state[1]) begin
+                mgnt_tx_buf <=  mgnt_reg_ftm_if[sys_req_addr];  
+            end
+            else if (mgnt_state[2]) begin
+                mgnt_tx_cnt <=  mgnt_tx_cnt + 1'b1;
+                mgnt_tx_buf <=  mgnt_tx_buf << 8;
+            end
+            if (mgnt_state[0]) begin
+                mgnt_rx_cnt <=  'b0;
+            end
+            else if (mgnt_state[3] && sys_req_data_valid) begin
+                mgnt_rx_cnt <=  mgnt_rx_cnt + 1'b1;
+                mgnt_rx_buf <=  {mgnt_rx_buf, sys_req_data};
+            end
+        end
+    end
+
+    assign  sys_resp_data   =   mgnt_tx_buf[(MGNT_REG_WIDTH-1)-:8];
+
+    always @(posedge clk_if) begin
+        if (!rst_if) begin
+            sys_req_ack         <=  'b0;
+            sys_resp_data_valid <=  'b0;
+        end
+        else begin
+            if (mgnt_state[1]) begin
+                sys_resp_data_valid <=  'b1;
+            end
+            else if (mgnt_state[2] && mgnt_tx_cnt == {MGNT_REG_WIDTH_L2{1'b1}}) begin
+                sys_resp_data_valid <=  'b0;
+            end
+            if (mgnt_state_next[5]) begin
+                sys_req_ack         <=  'b1;
+            end
+            else if (mgnt_state_next[0]) begin
+                sys_req_ack         <=  'b0;
+            end
+        end
+    end
+
+    always @(posedge clk_if) begin
+        if (!rst_if) begin
+            mgnt_reg_ftm_if[MGNT_FTM_ADDR_BRIDGE]   <=  16'h8;
+            mgnt_reg_ftm_if[MGNT_FTM_ADDR_MACCTL]   <=  16'h0;
+            mgnt_reg_ftm_if[MGNT_FTM_ADDR_ACCCTL]   <=  16'h8;
+            mgnt_reg_ftm_if[MGNT_FTM_ADDR_DEFRT0]   <=  16'h8;
+            mgnt_reg_ftm_if[MGNT_FTM_ADDR_DEFRT1]   <=  16'hF;
+        end
+        else begin
+            if (mgnt_state[4] && mgnt_rx_addr == MGNT_FTM_ADDR_BRIDGE) begin
+                mgnt_reg_ftm_if[MGNT_FTM_ADDR_BRIDGE]   <=  mgnt_rx_buf;
+            end
+            else if (mgnt_state[4] && mgnt_rx_addr == MGNT_FTM_ADDR_MACCTL) begin
+                mgnt_reg_ftm_if[MGNT_FTM_ADDR_MACCTL]   <=  mgnt_rx_buf;
+            end
+            else if (mgnt_state[4] && mgnt_rx_addr == MGNT_FTM_ADDR_ACCCTL) begin
+                mgnt_reg_ftm_if[MGNT_FTM_ADDR_ACCCTL]   <=  mgnt_rx_buf;
+            end
+            else if (mgnt_state[4] && mgnt_rx_addr == MGNT_FTM_ADDR_DEFRT0) begin
+                mgnt_reg_ftm_if[MGNT_FTM_ADDR_DEFRT0]   <=  mgnt_rx_buf;
+            end
+            else if (mgnt_state[4] && mgnt_rx_addr == MGNT_FTM_ADDR_DEFRT1) begin
+                mgnt_reg_ftm_if[MGNT_FTM_ADDR_DEFRT1]   <=  mgnt_rx_buf;
+            end
+        end
+    end
+
+endmodule

--- a/rtl/mac/gmii/mac_top.v
+++ b/rtl/mac/gmii/mac_top.v
@@ -49,7 +49,7 @@ module mac_top(
     input             rx_tte_fifo_rd,
     output    [7:0]   rx_tte_fifo_dout,
     input             rx_tteptr_fifo_rd,
-	output    [15:0]  rx_tteptr_fifo_dout,
+	output    [19:0]  rx_tteptr_fifo_dout,
     output            rx_tteptr_fifo_empty,
 
     // output    [6:0]   port_addr,
@@ -98,6 +98,10 @@ wire    [55:0]  rx_conf_data;
 wire            tx_mgnt_valid;
 wire            tx_mgnt_resp;
 wire    [15:0]  tx_mgnt_data;
+
+wire            mac_conf_valid;
+wire    [ 1:0]  mac_conf_resp;
+wire    [ 3:0]  mac_conf_data;
 
 assign          GMII_TX_CLK =   clk_125;        
 
@@ -251,7 +255,10 @@ mac_r_gmii_tte #(
     .rx_mgnt_data(rx_mgnt_data),
     .rx_conf_valid(rx_conf_valid),
     .rx_conf_resp(rx_conf_resp),
-    .rx_conf_data(rx_conf_data)
+    .rx_conf_data(rx_conf_data),
+    .mac_conf_valid(mac_conf_valid),
+    .mac_conf_resp(mac_conf_resp[0]),
+    .mac_conf_data(mac_conf_data)
     );
 
 mac_t_gmii_tte_v4 u_mac_t_gmii(
@@ -281,7 +288,10 @@ mac_t_gmii_tte_v4 u_mac_t_gmii(
     .delay_fifo_full(delay_fifo_full),
     .tx_mgnt_valid(tx_mgnt_valid),
     .tx_mgnt_resp(tx_mgnt_resp),
-    .tx_mgnt_data(tx_mgnt_data)
+    .tx_mgnt_data(tx_mgnt_data),
+    .mac_conf_valid(mac_conf_valid),
+    .mac_conf_resp(mac_conf_resp[1]),
+    .mac_conf_data(mac_conf_data)
     );
 
 // mac_t_gmii_tte u_mac_t_gmii(
@@ -342,6 +352,7 @@ mac_ctrl #(
     .rx_conf_resp       ( rx_conf_resp               ),
     .tx_mgnt_valid      ( tx_mgnt_valid              ),
     .tx_mgnt_data       ( tx_mgnt_data        [15:0] ),
+    .mac_conf_resp      ( mac_conf_resp       [ 1:0] ),
     .sys_req_valid      ( sys_req_valid              ),
     .sys_req_wr         ( sys_req_wr                 ),
     .sys_req_addr       ( sys_req_addr        [ 7:0] ),
@@ -352,6 +363,8 @@ mac_ctrl #(
     .rx_conf_valid      ( rx_conf_valid              ),
     .rx_conf_data       ( rx_conf_data        [55:0] ),
     .tx_mgnt_resp       ( tx_mgnt_resp               ),
+    .mac_conf_valid     ( mac_conf_valid             ),
+    .mac_conf_data      ( mac_conf_data       [ 3:0] ),
     .sys_req_ack        ( sys_req_ack                ),
     .sys_resp_data_valid( sys_resp_data_valid        ),
     .sys_resp_data      ( sys_resp_data       [ 7:0] ),

--- a/rtl/registers_table/reg_v2.v
+++ b/rtl/registers_table/reg_v2.v
@@ -36,7 +36,7 @@ module register_v2 #(
     output                  spi_ack,
     output reg  [15:0]      spi_dout,
     // sys mgnt side interface, cmd channel
-    output reg  [ 5:0]      sys_req_valid,
+    output reg  [ 7:0]      sys_req_valid,
     output reg              sys_req_wr,
     output      [ 7:0]      sys_req_addr,
     input                   sys_req_ack,
@@ -59,7 +59,8 @@ module register_v2 #(
     localparam  PORT2_ADDR      =   7'h02;
     localparam  PORT3_ADDR      =   7'h03;
     localparam  BE_SW_ADDR      =   7'h40;
-    localparam  TTE_SW_ADDR     =   7'h41;
+    localparam  BE_SW_FTM_ADDR  =   7'h41;
+    localparam  TTE_SW_ADDR     =   7'h50;
     localparam  SPI_LOCAL_ADDR  =   7'h7F;
 
     // Write this register will immediately start a direct read or indirect write between reg hub and remote device;
@@ -142,6 +143,7 @@ module register_v2 #(
                     PORT2_ADDR      : reg_state_next = 4;
                     PORT3_ADDR      : reg_state_next = 4;
                     BE_SW_ADDR      : reg_state_next = 4;
+                    BE_SW_FTM_ADDR  : reg_state_next = 4;
                     TTE_SW_ADDR     : reg_state_next = 4;
                     SPI_LOCAL_ADDR  : reg_state_next = 32;
                     default: reg_state_next = 1;
@@ -287,12 +289,13 @@ module register_v2 #(
         else begin
             if (reg_state[1]) begin
                 case(reg_dev_ptr[14:8])
-                    PORT0_ADDR : begin sys_req_valid <= 'h01; sys_req_wr <= reg_dev_ptr[15]; end
-                    PORT1_ADDR : begin sys_req_valid <= 'h02; sys_req_wr <= reg_dev_ptr[15]; end
-                    PORT2_ADDR : begin sys_req_valid <= 'h04; sys_req_wr <= reg_dev_ptr[15]; end
-                    PORT3_ADDR : begin sys_req_valid <= 'h08; sys_req_wr <= reg_dev_ptr[15]; end
-                    BE_SW_ADDR : begin sys_req_valid <= 'h10; sys_req_wr <= reg_dev_ptr[15]; end
-                    TTE_SW_ADDR: begin sys_req_valid <= 'h20; sys_req_wr <= reg_dev_ptr[15]; end
+                    PORT0_ADDR      : begin sys_req_valid <= 'h01; sys_req_wr <= reg_dev_ptr[15]; end
+                    PORT1_ADDR      : begin sys_req_valid <= 'h02; sys_req_wr <= reg_dev_ptr[15]; end
+                    PORT2_ADDR      : begin sys_req_valid <= 'h04; sys_req_wr <= reg_dev_ptr[15]; end
+                    PORT3_ADDR      : begin sys_req_valid <= 'h08; sys_req_wr <= reg_dev_ptr[15]; end
+                    BE_SW_ADDR      : begin sys_req_valid <= 'h10; sys_req_wr <= reg_dev_ptr[15]; end
+                    BE_SW_FTM_ADDR  : begin sys_req_valid <= 'h20; sys_req_wr <= reg_dev_ptr[15]; end
+                    TTE_SW_ADDR     : begin sys_req_valid <= 'h40; sys_req_wr <= reg_dev_ptr[15]; end
                     default: begin sys_req_valid <= 'b0; sys_req_wr <= 'b0; end
                 endcase
             end

--- a/rtl/switch_core/interface_mux_v3.v
+++ b/rtl/switch_core/interface_mux_v3.v
@@ -1,0 +1,266 @@
+`timescale 1ns / 1ps
+module interface_mux_v3 (
+    input           clk_sys,
+    input           rstn_sys,
+    // mac 0 if
+    output          rx_data_fifo_rd0,
+    input   [ 7:0]  rx_data_fifo_dout0,
+    output          rx_ptr_fifo_rd0,
+    input   [19:0]  rx_ptr_fifo_dout0,
+    input           rx_ptr_fifo_empty0,
+    // mac 1 if
+    output          rx_data_fifo_rd1,
+    input   [ 7:0]  rx_data_fifo_dout1,
+    output          rx_ptr_fifo_rd1,
+    input   [19:0]  rx_ptr_fifo_dout1,
+    input           rx_ptr_fifo_empty1,
+    // mac 2 if
+    output          rx_data_fifo_rd2,
+    input   [ 7:0]  rx_data_fifo_dout2,
+    output          rx_ptr_fifo_rd2,
+    input   [19:0]  rx_ptr_fifo_dout2,
+    input           rx_ptr_fifo_empty2,
+    // mac 3 if
+    output          rx_data_fifo_rd3,
+    input   [ 7:0]  rx_data_fifo_dout3,
+    output          rx_ptr_fifo_rd3,
+    input   [19:0]  rx_ptr_fifo_dout3,
+    input           rx_ptr_fifo_empty3,
+    // backend if
+    input           sfifo_rd,
+    output  [ 7:0]  sfifo_dout,
+    input           ptr_sfifo_rd,
+    output  [19:0]  ptr_sfifo_dout,
+    output          ptr_sfifo_empty
+);
+
+    (*MARK_DEBUG = "true"*) reg     [ 6:0]  ifmux_state, ifmux_state_next;
+
+    reg             bp;
+    reg             error;
+    (*MARK_DEBUG = "true"*) reg             tailtag;
+    reg     [12:0]  cnt;
+    reg     [ 1:0]  cnt_1;
+    reg     [12:0]  cnt_tgt;
+
+    // dest data fifo ctrl
+    reg     [ 1:0]  sfifo_wr;
+    reg             sfifo_en;
+    (*MARK_DEBUG = "true"*) reg     [ 7:0]  sfifo_din;
+    // wire    [13:0]  sfifo_cnt;
+    wire    [11:0]  sfifo_cnt;
+    // dest ptr fifo ctrl
+    reg             ptr_sfifo_wr;
+    (*MARK_DEBUG = "true"*) reg     [19:0]  ptr_sfifo_din;
+    wire            ptr_sfifo_full;
+    // src data fifo sel
+    (*EXTRACT_ENABLE = "no"*) reg     [ 3:0]  rx_data_fifo_rd;
+    (*MARK_DEBUG = "true"*) wire    [ 7:0]  rx_data_fifo_dout;
+    // src ptr fifo sel
+    reg     [ 3:0]  rx_ptr_fifo_rd;
+    (*MARK_DEBUG = "true"*) wire    [19:0]  rx_ptr_fifo_dout;
+
+
+    reg     [ 1:0]  ifmux_rndrb;
+    reg     [ 3:0]  ifmux_sel;
+    reg     [ 1:0]  ifmux_sel_bin;
+    wire    [ 3:0]  ifmux_rr_vec_out;
+    wire    [ 1:0]  ifmux_rr_bin_out;
+    wire    [ 3:0]  rx_rdy;
+    assign          rx_rdy  =   {!rx_ptr_fifo_empty3, !rx_ptr_fifo_empty2, !rx_ptr_fifo_empty1, !rx_ptr_fifo_empty0};
+
+    rnd_rb_ppe #(
+        .RR_WIDTH       (4)
+    ) u_rndrb (
+        .rr_vec_in      (rx_rdy),
+        .rr_priority    (ifmux_rndrb),
+        .rr_vec_out     (ifmux_rr_vec_out),
+        .rr_bin_out     (ifmux_rr_bin_out)
+    );
+
+    always @(*) begin
+        case(ifmux_state)
+            01: ifmux_state_next    =   (rx_rdy != 'b0 && !bp) ? 2 : 1;
+            02: ifmux_state_next    =   4;
+            04: ifmux_state_next    =   8;
+            08: ifmux_state_next    =   16;
+            16: ifmux_state_next    =   (cnt != cnt_tgt) ? 16 :
+                                        tailtag ? 32 : 64;
+            32: ifmux_state_next    =   64;
+            64: ifmux_state_next    =   (cnt_1 == 2'b11) ? 1 : 64;
+            default: ifmux_state_next = ifmux_state;
+        endcase
+    end
+
+    always @(posedge clk_sys or negedge rstn_sys) begin
+        if (!rstn_sys) begin
+            ifmux_state <=  1;
+        end
+        else begin
+            ifmux_state <=  ifmux_state_next;
+        end
+    end
+
+    always @(posedge clk_sys or negedge rstn_sys) begin
+        if (!rstn_sys) begin
+            ifmux_rndrb     <=  'b0;
+            ifmux_sel       <=  'b0;
+            ifmux_sel_bin   <=  'b0;
+        end
+        else begin
+            // if (ifmux_state_next == 2) begin
+            if (ifmux_state_next[1]) begin
+                ifmux_rndrb     <=  ifmux_rr_bin_out + 1'b1;
+                ifmux_sel       <=  ifmux_rr_vec_out;
+                ifmux_sel_bin   <=  ifmux_rr_bin_out;
+            end
+        end
+    end
+
+    always @(posedge clk_sys or negedge rstn_sys) begin
+        if (!rstn_sys) begin
+            // cnt             <=  'b1;
+            // cnt_1           <=  'b0;
+            // cnt_tgt         <=  'b0;
+            // error           <=  'b0;
+            sfifo_en        <=  'b0;
+            sfifo_wr        <=  'b0;
+            ptr_sfifo_wr    <=  'b0;
+            rx_ptr_fifo_rd  <=  'b0;
+            rx_data_fifo_rd <=  'b0;
+        end
+        else begin
+            // cnt block ctrl
+            // if (rx_data_fifo_rd != 0) begin
+            if (!ifmux_state[0]) begin
+                cnt     <=  cnt + 1'b1;
+            end
+            else begin
+                cnt     <=  'h1;
+            end
+            // if (ifmux_state == 32) begin
+            if (ifmux_state[6]) begin
+                cnt_1   <=  cnt_1 + 1'b1;
+            end
+            else begin
+                cnt_1   <=  'b0;
+            end
+            // rx data read
+            // if (ifmux_state_next == 2) begin
+            if (ifmux_state_next[1]) begin
+                rx_data_fifo_rd <=  ifmux_rr_vec_out;
+            end
+            // else if (ifmux_state_next == 1) begin
+            // else if (ifmux_state_next[0]) begin
+            else if (ifmux_state[6] && cnt_1 == 2'b11) begin
+                rx_data_fifo_rd <=  'b0;
+            end
+            // rx ptr read
+            // if (ifmux_state_next == 2) begin
+            if (ifmux_state_next[1]) begin
+                rx_ptr_fifo_rd  <=  ifmux_rr_vec_out;
+            end
+            // else if (ifmux_state_next == 4) begin
+            else if (ifmux_state[1]) begin
+                rx_ptr_fifo_rd  <=  'b0;
+            end
+            // sfifo valid
+            // if (ifmux_state_next == 2) begin
+            if (ifmux_state[1]) begin
+                sfifo_en        <=  'b1;
+            end
+            // else if (ifmux_state_next == 32) begin
+            else if (ifmux_state[5] || ifmux_state[6]) begin
+                sfifo_en        <=  'b0;
+            end 
+            // other ctrl signal
+            // if (ifmux_state == 4) begin
+            if (ifmux_state[2]) begin
+                cnt_tgt         <=  rx_ptr_fifo_dout[11:0];
+                tailtag         <=  rx_ptr_fifo_dout[12];
+                error           <=  rx_ptr_fifo_dout[15] || rx_ptr_fifo_dout[14] || rx_ptr_fifo_dout[13];
+            end
+            // if (ifmux_state != 1) begin
+            if (!ifmux_state[0]) begin
+                // sfifo_wr        <=  !error;
+                // sfifo_wr        <=  {sfifo_wr[0], !error && sfifo_en};
+                sfifo_wr        <=  {!error && sfifo_wr[0], sfifo_en};
+                // sfifo_din       <=  rx_data_fifo_dout;
+                sfifo_din       <=  rx_data_fifo_dout;
+            end
+            // if (ifmux_state == 8) begin
+            if (ifmux_state[3]) begin
+                ptr_sfifo_wr    <=  !error;
+                ptr_sfifo_din   <=  {rx_ptr_fifo_dout[19:16], ifmux_sel, 1'b0, cnt_tgt[10:0]};
+            end
+            else begin
+                ptr_sfifo_wr    <=  'b0;
+            end
+        end
+    end
+
+    always @(posedge clk_sys or negedge rstn_sys) begin
+        if (!rstn_sys) begin
+            bp  <=  'b1;
+        end
+        else begin
+            // if (sfifo_cnt[13:8] >= 'h3A || ptr_sfifo_full) begin
+            if (sfifo_cnt[11:8] >= 'h0A || ptr_sfifo_full) begin
+                bp  <=  'b1;
+            end
+            else begin
+                bp  <=  'b0;
+            end
+        end
+    end
+
+    assign  rx_data_fifo_rd0    =   rx_data_fifo_rd[0];
+    assign  rx_data_fifo_rd1    =   rx_data_fifo_rd[1];
+    assign  rx_data_fifo_rd2    =   rx_data_fifo_rd[2];
+    assign  rx_data_fifo_rd3    =   rx_data_fifo_rd[3];
+    assign  rx_ptr_fifo_rd0     =   rx_ptr_fifo_rd[0];
+    assign  rx_ptr_fifo_rd1     =   rx_ptr_fifo_rd[1];
+    assign  rx_ptr_fifo_rd2     =   rx_ptr_fifo_rd[2];
+    assign  rx_ptr_fifo_rd3     =   rx_ptr_fifo_rd[3];
+    assign  rx_ptr_fifo_dout    =   (ifmux_sel[0])  ?   rx_ptr_fifo_dout0   :
+                                    (ifmux_sel[1])  ?   rx_ptr_fifo_dout1   :
+                                    (ifmux_sel[2])  ?   rx_ptr_fifo_dout2   :
+                                    rx_ptr_fifo_dout3;    
+    assign  rx_data_fifo_dout   =   (ifmux_sel[0])  ?   rx_data_fifo_dout0  :
+                                    (ifmux_sel[1])  ?   rx_data_fifo_dout1  :
+                                    (ifmux_sel[2])  ?   rx_data_fifo_dout2  :
+                                    rx_data_fifo_dout3; 
+
+    (*MARK_DEBUG="true"*) wire  dbg_data_of;
+    (*MARK_DEBUG="true"*) wire  dbg_data_uf;
+    (*MARK_DEBUG="true"*) wire  dbg_ptr_of;
+    (*MARK_DEBUG="true"*) wire  dbg_ptr_uf;
+
+    sfifo_reg_w8_d4k    u_sfifo(
+        .clk(clk_sys),
+        .rst(!rstn_sys),
+        .din(sfifo_din),
+        .wr_en(sfifo_wr[1]),
+        .rd_en(sfifo_rd),
+        .dout(sfifo_dout),
+        .full(), 							
+        .empty(), 					
+        .data_count(sfifo_cnt),
+        .underflow(dbg_data_uf),
+        .overflow(dbg_data_of)	
+        );
+    sfifo_w20_d32   u_ptr_sfifo(
+            .clk(clk_sys),
+            .rst(!rstn_sys),
+            .din(ptr_sfifo_din),
+            .wr_en(ptr_sfifo_wr),
+            .rd_en(ptr_sfifo_rd),
+            .dout(ptr_sfifo_dout),
+            .empty(ptr_sfifo_empty),
+            .full(ptr_sfifo_full),
+            .data_count(),
+            .underflow(dbg_ptr_uf),
+            .overflow(dbg_ptr_of)	
+        );
+
+endmodule

--- a/rtl/switch_core/interface_mux_v3.v
+++ b/rtl/switch_core/interface_mux_v3.v
@@ -34,11 +34,11 @@ module interface_mux_v3 (
     output          ptr_sfifo_empty
 );
 
-    (*MARK_DEBUG = "true"*) reg     [ 6:0]  ifmux_state, ifmux_state_next;
+    reg     [ 6:0]  ifmux_state, ifmux_state_next;
 
     reg             bp;
     reg             error;
-    (*MARK_DEBUG = "true"*) reg             tailtag;
+    reg             tailtag;
     reg     [12:0]  cnt;
     reg     [ 1:0]  cnt_1;
     reg     [12:0]  cnt_tgt;
@@ -46,19 +46,19 @@ module interface_mux_v3 (
     // dest data fifo ctrl
     reg     [ 1:0]  sfifo_wr;
     reg             sfifo_en;
-    (*MARK_DEBUG = "true"*) reg     [ 7:0]  sfifo_din;
+    reg     [ 7:0]  sfifo_din;
     // wire    [13:0]  sfifo_cnt;
     wire    [11:0]  sfifo_cnt;
     // dest ptr fifo ctrl
     reg             ptr_sfifo_wr;
-    (*MARK_DEBUG = "true"*) reg     [19:0]  ptr_sfifo_din;
+    reg     [19:0]  ptr_sfifo_din;
     wire            ptr_sfifo_full;
     // src data fifo sel
     (*EXTRACT_ENABLE = "no"*) reg     [ 3:0]  rx_data_fifo_rd;
-    (*MARK_DEBUG = "true"*) wire    [ 7:0]  rx_data_fifo_dout;
+    wire    [ 7:0]  rx_data_fifo_dout;
     // src ptr fifo sel
     reg     [ 3:0]  rx_ptr_fifo_rd;
-    (*MARK_DEBUG = "true"*) wire    [19:0]  rx_ptr_fifo_dout;
+    wire    [19:0]  rx_ptr_fifo_dout;
 
 
     reg     [ 1:0]  ifmux_rndrb;

--- a/rtl/switch_core/switch_post.v
+++ b/rtl/switch_core/switch_post.v
@@ -56,6 +56,7 @@ module switch_post (
     reg   [11:0] frame_len;
     reg   [11:0] frame_len_1;
     reg   [ 7:0] frame_len_with_pad;
+    reg   [ 3:0] frame_port_src;
 
     always @(posedge clk or negedge rstn)
         if (!rstn) begin
@@ -65,6 +66,7 @@ module switch_post (
             frame_len <= #2 0;
             frame_len_1 <= #2 0;
             frame_len_with_pad <= #2 0;
+            frame_port_src <= #2 0;
             o_cell_data_fifo_rd <= #2 0;
             data_fifo_din <= #2 0;
             ptr_fifo_wr <= #2 0;
@@ -81,15 +83,19 @@ module switch_post (
                     // byte_dv  <= #2 0;
                     // byte_cnt <= #2 2;
                     if (!o_cell_data_fifo_empty & o_cell_data_fifo_dout[143] & !bp) begin
-                        frame_len <= #2{
-                            o_cell_data_fifo_dout[127:124], o_cell_data_fifo_dout[119:112]
-                        };
+                        // frame_len <= #2{
+                        //     o_cell_data_fifo_dout[127:124], o_cell_data_fifo_dout[119:112]
+                        // };
+                        frame_len <= #2 o_cell_data_fifo_dout[123:112];
                         // frame_len_with_pad <= #2{
                         //     o_cell_data_fifo_dout[127:124], o_cell_data_fifo_dout[119:112],
                         // };
-                        frame_len_with_pad <= #2{
-                            o_cell_data_fifo_dout[127:124], o_cell_data_fifo_dout[119:118], 2'b0
-                        };
+                        // frame_len_with_pad <= #2{
+                        //     o_cell_data_fifo_dout[127:124], o_cell_data_fifo_dout[119:118], 2'b0
+                        // };
+                        frame_len_with_pad <= #2 {o_cell_data_fifo_dout[123:118], 2'b0};
+                        // frame_port_src <= #2 o_cell_data_fifo_dout[123:120];
+                        frame_port_src <= #2 o_cell_data_fifo_dout[127:124];
                         mstate <= #2 1;
                     end else if (!o_cell_data_fifo_empty & !bp) begin
                         mstate <= #2 19;
@@ -177,7 +183,8 @@ module switch_post (
                 end
                 18: begin
                     data_fifo_din <= #2 o_cell_data_fifo_dout[7:0];
-                    ptr_fifo_din <= #2{4'b0, frame_len_1[11:0]};
+                    // ptr_fifo_din <= #2{4'b0, frame_len_1[11:0]};
+                    ptr_fifo_din <= #2{frame_port_src, frame_len_1[11:0]};
                     ptr_fifo_wr <= #2 1;
                     mstate <= #2 0;
                 end

--- a/rtl/switch_core/switch_pre.v
+++ b/rtl/switch_core/switch_pre.v
@@ -19,7 +19,7 @@ always@(posedge clk or negedge rstn)
 	if(!rstn)
 		begin
 		// word_num<=#2  0;
-		state<=#2  0;
+		state<=#2  17;
 		// i_cell_data_fifo_dout<=#2  0;
 		// i_cell_portmap<=#2  0;
 		i_cell_data_fifo_wr<=#2  0;
@@ -30,15 +30,18 @@ always@(posedge clk or negedge rstn)
 		i_cell_data_fifo_wr<=#2  0;
 		i_cell_ptr_fifo_wr<=#2  0;
 		case(state)
-		0:begin
+		17:begin
 			word_num<=#2  0;
 			if(sof & !i_cell_bp)begin
-				// i_cell_data_fifo_dout[127:120]<=#2  din;
-				i_cell_data_fifo_dout<=#2 {i_cell_data_fifo_dout, din};
 				i_cell_portmap<=#2  din[3:0];
-				state<=#2  1;
+				state<=#2  0;
 				end
-			end
+		end
+		0:begin
+			// i_cell_data_fifo_dout[127:120]<=#2  din;
+			i_cell_data_fifo_dout<=#2 {i_cell_data_fifo_dout, din};
+			state<=#2  1;
+		end
 		1:begin
 			// i_cell_data_fifo_dout[119:112]<=#2  din;
 			i_cell_data_fifo_dout<=#2 {i_cell_data_fifo_dout, din};
@@ -125,7 +128,7 @@ always@(posedge clk or negedge rstn)
 			else begin
 				i_cell_ptr_fifo_dout<=#2  {4'b0,i_cell_portmap[3:0],2'b0,word_num[7:2]};
 				i_cell_ptr_fifo_wr<=#2  1;
-				state<=#2 0;
+				state<=#2 17;
 				end
 			end
 		endcase

--- a/rtl/switch_core/util/switch_ctrl.v
+++ b/rtl/switch_core/util/switch_ctrl.v
@@ -95,6 +95,7 @@ module switch_ctrl #(
     localparam  MGNT_SW_FRP_FUNC_FT_FWD_DISABLE     =   'h08;
     localparam  MGNT_SW_FRP_FUNC_FT_LRN_DISABLE     =   'h09;
     localparam  MGNT_SW_FRP_FUNC_FT_AGING_ITVL      =   'h0A;
+    localparam  MGNT_SW_FRP_FUNC_FT_RSVD_MULTICAST  =   'h0B;
     // localparam  MGNT_SW_FRP_FUNC_FT_FLUSH           =   'h0E;
     localparam  MGNT_SW_FRP_FUNC_CLR                =   'h0F;
     // frame_process reg addr, tte mode
@@ -111,7 +112,7 @@ module switch_ctrl #(
     localparam  MGNT_SW_SWC_ADDR_ERR_BP             =   'h14;
     localparam  MGNT_SW_SWC_FUNC_CLR                =   'h1F;
 
-    localparam  MGNT_REG_FRP_DEPTH                  =   (SW_CTRL_TYPE == "TTE") ? 4 : 11;
+    localparam  MGNT_REG_FRP_DEPTH                  =   (SW_CTRL_TYPE == "TTE") ? 4 : 12;
     localparam  MGNT_REG_SWC_DEPTH                  =   5;
 
     integer i;
@@ -335,6 +336,10 @@ module switch_ctrl #(
                 end
                 else if (mgnt_state_next[4] && mgnt_rx_addr == MGNT_SW_FRP_FUNC_FT_AGING_ITVL) begin
                     mgnt_reg_frp[MGNT_SW_FRP_FUNC_FT_AGING_ITVL]            <=  mgnt_rx_buf;
+                    mgnt_rx_rmt                                             <=  1'b1;
+                end
+                else if (mgnt_state_next[4] && mgnt_rx_addr == MGNT_SW_FRP_FUNC_FT_RSVD_MULTICAST) begin
+                    mgnt_reg_frp[MGNT_SW_FRP_FUNC_FT_RSVD_MULTICAST]        <=  mgnt_rx_buf;
                     mgnt_rx_rmt                                             <=  1'b1;
                 end
                 else if (mgnt_state_next[4]) begin

--- a/rtl/top_switch.v
+++ b/rtl/top_switch.v
@@ -105,7 +105,7 @@ module top_switch (
     wire        emac0_rx_tte_fifo_rd;
     wire [ 7:0] emac0_rx_tte_fifo_dout;
     wire        emac0_rx_tteptr_fifo_rd;
-    wire [15:0] emac0_rx_tteptr_fifo_dout;
+    wire [19:0] emac0_rx_tteptr_fifo_dout;
     wire        emac0_rx_tteptr_fifo_empty;
 
     wire        emac1_interface_clk;
@@ -131,7 +131,7 @@ module top_switch (
     wire        emac1_rx_tte_fifo_rd;
     wire [ 7:0] emac1_rx_tte_fifo_dout;
     wire        emac1_rx_tteptr_fifo_rd;
-    wire [15:0] emac1_rx_tteptr_fifo_dout;
+    wire [19:0] emac1_rx_tteptr_fifo_dout;
     wire        emac1_rx_tteptr_fifo_empty;
 
     wire        emac2_interface_clk;
@@ -157,7 +157,7 @@ module top_switch (
     wire        emac2_rx_tte_fifo_rd;
     wire [ 7:0] emac2_rx_tte_fifo_dout;
     wire        emac2_rx_tteptr_fifo_rd;
-    wire [15:0] emac2_rx_tteptr_fifo_dout;
+    wire [19:0] emac2_rx_tteptr_fifo_dout;
     wire        emac2_rx_tteptr_fifo_empty;
 
     wire        emac3_interface_clk;
@@ -183,7 +183,7 @@ module top_switch (
     wire        emac3_rx_tte_fifo_rd;
     wire [ 7:0] emac3_rx_tte_fifo_dout;
     wire        emac3_rx_tteptr_fifo_rd;
-    wire [15:0] emac3_rx_tteptr_fifo_dout;
+    wire [19:0] emac3_rx_tteptr_fifo_dout;
     wire        emac3_rx_tteptr_fifo_empty;
 
     wire [ 1:0] emac0_speed;
@@ -220,7 +220,7 @@ module top_switch (
     // wire        port3_req;
     // wire        port3_ack;
 
-    wire    [ 5:0]  sys_req_valid;
+    wire    [ 7:0]  sys_req_valid;
     wire            sys_req_wr;
     wire    [ 7:0]  sys_req_addr;
     wire            sys_req_ack;
@@ -246,26 +246,32 @@ module top_switch (
     wire            sys_resp_data_valid_be;
     wire            sys_req_ack_tte;
     wire    [ 7:0]  sys_resp_data_tte;
-    wire            sys_resp_data_valid_tte;  
+    wire            sys_resp_data_valid_tte;
+    wire            sys_req_ack_ftm;
+    wire    [ 7:0]  sys_resp_data_ftm;
+    wire            sys_resp_data_valid_ftm;  
 
-    assign  sys_req_ack         =   sys_req_ack_p0 ||
-                                    sys_req_ack_p1 ||
-                                    sys_req_ack_p2 ||
-                                    sys_req_ack_p3 ||
-                                    sys_req_ack_be ||
-                                    sys_req_ack_tte;
-    assign  sys_resp_data_valid =   sys_resp_data_valid_p0 ||
-                                    sys_resp_data_valid_p1 ||
-                                    sys_resp_data_valid_p2 ||
-                                    sys_resp_data_valid_p3 ||
-                                    sys_resp_data_valid_be ||
-                                    sys_resp_data_valid_tte;
-    assign  sys_resp_data       =   (sys_resp_data_valid_p0) ? sys_resp_data_p0 :
-                                    (sys_resp_data_valid_p1) ? sys_resp_data_p1 :
-                                    (sys_resp_data_valid_p2) ? sys_resp_data_p2 :
-                                    (sys_resp_data_valid_p3) ? sys_resp_data_p3 :
-                                    (sys_resp_data_valid_be) ? sys_resp_data_be :
-                                    sys_resp_data_tte;
+    assign  sys_req_ack         =   sys_req_ack_p0  ||
+                                    sys_req_ack_p1  ||
+                                    sys_req_ack_p2  ||
+                                    sys_req_ack_p3  ||
+                                    sys_req_ack_be  ||
+                                    sys_req_ack_tte ||
+                                    sys_req_ack_ftm;
+    assign  sys_resp_data_valid =   sys_resp_data_valid_p0  ||
+                                    sys_resp_data_valid_p1  ||
+                                    sys_resp_data_valid_p2  ||
+                                    sys_resp_data_valid_p3  ||
+                                    sys_resp_data_valid_be  ||
+                                    sys_resp_data_valid_tte ||
+                                    sys_resp_data_valid_ftm;
+    assign  sys_resp_data       =   (sys_resp_data_valid_p0)  ? sys_resp_data_p0  :
+                                    (sys_resp_data_valid_p1)  ? sys_resp_data_p1  :
+                                    (sys_resp_data_valid_p2)  ? sys_resp_data_p2  :
+                                    (sys_resp_data_valid_p3)  ? sys_resp_data_p3  :
+                                    (sys_resp_data_valid_be)  ? sys_resp_data_be  :
+                                    (sys_resp_data_valid_tte) ? sys_resp_data_tte :
+                                    sys_resp_data_ftm;
 
     wire [31:0] counter_ns;
 
@@ -283,7 +289,8 @@ module top_switch (
 
     mac_top #(
         .MAC_PORT(0),
-        .RX_DELAY(11)
+        // .RX_DELAY(11)
+        .RX_DELAY(8)
     ) u_mac_top_0 (
         .clk(clk),
         .clk_ref(clk_in),
@@ -350,7 +357,8 @@ module top_switch (
 
     mac_top #(
         .MAC_PORT(1),
-        .RX_DELAY(10)
+        // .RX_DELAY(10)
+        .RX_DELAY(2)
     ) u_mac_top_1 (
         .clk(clk),
         .clk_ref(clk_in),
@@ -418,7 +426,8 @@ module top_switch (
 
     mac_top #(
         .MAC_PORT(2),
-        .RX_DELAY(9)
+        // .RX_DELAY(9)
+        .RX_DELAY(0)
     ) u_mac_top_2 (
         .clk(clk),
         .clk_ref(clk_in),
@@ -486,7 +495,8 @@ module top_switch (
 
     mac_top #(
         .MAC_PORT(3),
-        .RX_DELAY(9)
+        // .RX_DELAY(9)
+        .RX_DELAY(4)
     ) u_mac_top_3 (
         .clk(clk),
         .clk_ref(clk_in),
@@ -558,9 +568,7 @@ module top_switch (
     wire        ptr_sfifo_rd;
     wire [19:0] ptr_sfifo_dout;
     wire        ptr_sfifo_empty;
-    interface_mux_v2 #(
-        .IFMUX_MODE("LLDP")
-    ) u_interface_mux (
+    interface_mux_v3 u_interface_mux (
         .clk_sys(clk),
         .rstn_sys(rstn_sys),
         .rx_data_fifo_dout0(emac0_rx_data_fifo_dout),
@@ -597,11 +605,9 @@ module top_switch (
     wire        tte_sfifo_rd;
     wire [ 7:0] tte_sfifo_dout;
     wire        tteptr_sfifo_rd;
-    wire [15:0] tteptr_sfifo_dout;
+    wire [19:0] tteptr_sfifo_dout;
     wire        tteptr_sfifo_empty;
-    interface_mux_v2 #(
-        .IFMUX_MODE("TTE")
-    ) u_tteinterface_mux (
+    interface_mux_v3 u_tteinterface_mux (
         .clk_sys(clk),
         .rstn_sys(rstn_sys),
         .rx_data_fifo_dout0(emac0_rx_tte_fifo_dout),
@@ -655,6 +661,11 @@ module top_switch (
     wire        se_nak;
     wire        aging_req;
     wire        aging_ack;
+
+    wire        ftm_req_valid;
+    wire        ftm_resp_ack;
+    wire        ftm_resp_nak;
+    wire [15:0] ftm_resp_result;
 
     wire        fp_stat_valid;
     wire        fp_stat_resp;
@@ -728,6 +739,11 @@ module top_switch (
         .se_hash(se_hash),
         .link(link),
         
+        .ftm_req_valid(ftm_req_valid),
+        .ftm_resp_ack(ftm_resp_ack),
+        .ftm_resp_nak(ftm_resp_nak),
+        .ftm_resp_result(ftm_resp_result),
+
         .fp_stat_valid(fp_stat_valid),
         .fp_stat_resp(fp_stat_resp),
         .fp_stat_data(fp_stat_data),
@@ -750,6 +766,29 @@ module top_switch (
         .se_mac(se_mac),
         .aging_req(),
         .aging_ack()
+    );
+
+    hash_multicast #(
+        .MGNT_REG_WIDTH ( 16 )
+    ) u_hash_multicast (
+        .clk_if                  ( clk_125                     ),
+        .rst_if                  ( rstn_sys                    ),
+        .clk_sys                 ( clk                         ),
+        .rst_sys                 ( rstn_sys                    ),
+        .ftm_req_valid           ( ftm_req_valid               ),
+        .ftm_req_mac             ( se_mac               [15:0] ),
+        .sys_req_valid           ( sys_req_valid           [5] ),
+        .sys_req_wr              ( sys_req_wr                  ),
+        .sys_req_addr            ( sys_req_addr         [ 7:0] ),
+        .sys_req_data            ( sys_req_data         [ 7:0] ),
+        .sys_req_data_valid      ( sys_req_data_valid          ),
+
+        .ftm_resp_ack            ( ftm_resp_ack                ),
+        .ftm_resp_nak            ( ftm_resp_nak                ),
+        .ftm_resp_result         ( ftm_resp_result      [15:0] ),
+        .sys_req_ack             ( sys_req_ack_ftm             ),
+        .sys_resp_data           ( sys_resp_data_ftm    [ 7:0] ),
+        .sys_resp_data_valid     ( sys_resp_data_valid_ftm     )
     );
 
     switch_top_v2 switch (
@@ -834,7 +873,7 @@ module top_switch (
         .fp_conf_resp            ( tte_fp_conf_resp            ),
         .swc_mgnt_valid          ( tte_swc_mgnt_valid          ),
         .swc_mgnt_data           ( tte_swc_mgnt_data    [ 3:0] ),
-        .sys_req_valid           ( sys_req_valid           [5] ),
+        .sys_req_valid           ( sys_req_valid           [6] ),
         .sys_req_wr              ( sys_req_wr                  ),
         .sys_req_addr            ( sys_req_addr         [ 7:0] ),
         .sys_req_data            ( sys_req_data         [ 7:0] ),
@@ -969,7 +1008,7 @@ module top_switch (
         .spi_din(spi_din),
         .spi_ack(spi_ack),
         .spi_dout(spi_dout),
-        .sys_req_valid           ( sys_req_valid   [ 5:0]  ),
+        .sys_req_valid           ( sys_req_valid   [ 7:0]  ),
         .sys_req_wr              ( sys_req_wr              ),
         .sys_req_addr            ( sys_req_addr    [ 7:0]  ),
         .sys_req_ack             ( sys_req_ack             ),


### PR DESCRIPTION
- "Master" port func added
    - "Master" port will append port-related information when rqd
    - "Master" port can designate egress port per-packet
- Dedicated flow table for multicast packet added
    - Certain multicast packet can be sent only to designated port(s) or dropped

